### PR TITLE
Update main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -52,7 +52,7 @@ def run(textin):
     defineVariables()
     try:
         #deletes all old images in the output directory before running
-        shutil.rmtree(outputdir)
+        #shutil.rmtree(outputdir)
         os.mkdir(outputdir)
     except:
         #if it is already not there, make it without erroring. Won't catch or care about other errors, so I hope there is no issue


### PR DESCRIPTION
shutil.rmtree is dangerous, and isn't necessary here.

I would prefer to keep all the old images, and just use a timestamp such as hh_image_2023-10-18T14-14-14.jpeg or something to differentiate between the images. If I want to delete them I can do it manually.