### PR TITLE
Discord formatting, Tweet length, and Facebook link

### DIFF
--- a/main.py
+++ b/main.py
@@ -91,7 +91,6 @@ def run(textin, title, link, pubdate):
     text = rpHTML.replaceAmpersandCodes()
     #------------------------------- END VARIABLES -------------------------------#
     #------------------------------ DISCORD WEBHOOK ------------------------------#
-    print()
 
     try:
         #Trying to post to discord
@@ -112,7 +111,6 @@ def run(textin, title, link, pubdate):
         print("\033[33m" + "The Program is still running, but the Discord post was not made." + "\033[0m")
     #------------------------------- END DISCORD WEBHOOK -------------------------------#
     #---------------------------------- FACEBOOK BOT ---------------------------------#
-    print()
 
     try:
         fb = facebook.GraphAPI(access_token=fb_app_token, version="2.12")
@@ -128,7 +126,10 @@ def run(textin, title, link, pubdate):
             connection_name="feed",
             message=fbtext,
             link=updated_link)
-        print("Facebook news was posted")
+        feed = fb.get_connections(fb_page_id, "feed")
+        last_post = feed["data"][0]["id"]
+        post_id = last_post.split("_")[1]
+        print("Facebook news was posted - https://www.facebook.com/HelioHost.org/posts/" + post_id)
     except Exception as f:
         print("\033[31m" + "An Exception Occured while attempting to post to Facebook, but was caught. Here is the error:")
         #traceback.print_tb(f.__traceback__)
@@ -136,7 +137,6 @@ def run(textin, title, link, pubdate):
         print("\033[33m" + "The Program is still running, but the Facebook post was not made." + "\033[0m")
     #-------------------------------- END FACEBOOK BOT -------------------------------#
     #---------------------------------- TWITTER BOT ----------------------------------#
-    print()
 
     # Authenticate to Twitter
     try:
@@ -146,13 +146,11 @@ def run(textin, title, link, pubdate):
         )
 
         if (len(tweettext) > 256):
-            response = client.create_tweet(text=tweettext[:253] + "... " + updated_link)
-            print("Twitter news was posted")
-            print(f"https://twitter.com/user/status/{response.data['id']}")
+            response = client.create_tweet(text=tweettext[:233] + "... " + updated_link)
+            print(f"Twitter news was posted - https://twitter.com/user/status/{response.data['id']}")
         else:
             response = client.create_tweet(text=tweettext + " " + updated_link)
-            print("Twitter news was posted")
-            print(f"https://twitter.com/user/status/{response.data['id']}")
+            print(f"Twitter news was posted - https://twitter.com/user/status/{response.data['id']}")
     except Exception as t:
         print("\033[31m" + "An Exception Occured while attempting to post to Twitter, but was caught. Here is the error:")
         #traceback.print_tb(t.__traceback__)
@@ -161,7 +159,6 @@ def run(textin, title, link, pubdate):
 
     #------------------------------- END TWITTER BOT -------------------------------#
     #---------------------------------- INSTAGRAM BOT ----------------------------------#
-    print()
     
     if (instagram_app_token == ""):
         print("Skipping Instagram")

--- a/rss.py
+++ b/rss.py
@@ -25,10 +25,14 @@ def rss(url, last_modified=None):# store the etag and modified
             json.dump(data, f, indent=4)
         #print(feed_update["entries"][0])
         text = feed_update["entries"][0]["summary"]
+        text = text.replace("\t", "")
+        text = text.replace("\n \n\n\n", "\n\n")
         title = feed_update["entries"][0]["title"]
         link = feed_update["entries"][0]["link"]
         pubdate = feed_update["entries"][0]["published"]
+        print()
         print("New post in RSS feed: " + title + " " + pubdate)
+        print(repr(text))
         return (True, text, title, link, pubdate)
     else:
         return (False, None, None, None)


### PR DESCRIPTION
1. I cleaned up the Discord post by removing all tabs, and reducing the 4 new lines down to 2 new lines.
2. I also added a link to the Facebook post.
3. The tweet length needs to be looked at because just typing "helionet.org" or "heliohost.org" even without the http/s in the tweet counts as 23 characters instead of 12-13 characters like the len() reports. For now I just reduced the [:233] to make the latest news go through, but we need a better way to handle multiple links like this in the future.
4. I also removed some blank lines to make the console output cleaner, and printed the news text with \n when the RSS is imported.